### PR TITLE
Scoreboard with images

### DIFF
--- a/Encountify.Android/CustomMapRenderer.cs
+++ b/Encountify.Android/CustomMapRenderer.cs
@@ -73,7 +73,7 @@ namespace Encountify.Droid
 
                 if (infoPoints != null)
                 {
-                    infoPoints.Text = "500 POINTS✨";
+                    infoPoints.Text = "100 POINTS✨";
                 }
                 if (infoTitle != null)
                 {

--- a/Encountify/Models/ScoreboardCell.cs
+++ b/Encountify/Models/ScoreboardCell.cs
@@ -14,8 +14,6 @@ namespace Encountify.Models
 
         public ScoreboardCell(ScoreboardEntry entry)
         {
-            // IUser userData = DependencyService.Get<IUser>();
-            // User user = userData.GetAsync(entry.UserId).Result;
             Name = entry.Name;
             Score = entry.Score;
             ImageOpenClose = new Lazy<Image>(() => {
@@ -23,8 +21,6 @@ namespace Encountify.Models
                 User user = userData.GetAsync(entry.UserId).Result;
                 return new Image() { Source = ImageSource.FromStream(() => new MemoryStream(user.Picture)) };
             });
-            //ImageOpenClose = new Lazy<Image>();
-            //ImageOpenClose.Value.Source = ImageSource.FromStream(() => new MemoryStream(user.Picture));
         }
 
     }

--- a/Encountify/Models/ScoreboardCell.cs
+++ b/Encountify/Models/ScoreboardCell.cs
@@ -1,0 +1,31 @@
+﻿using Encountify.Services;
+using System;
+using System.IO;
+using Xamarin.Forms;
+
+namespace Encountify.Models
+{
+    public class ScoreboardCell
+    {
+        public string Name { get; set; }
+        public int Score { get; set; }
+        public ImageSource DownloadedImageSource { get; set; }
+        public Lazy<Image> ImageOpenClose { get; set; }
+
+        public ScoreboardCell(ScoreboardEntry entry)
+        {
+            // IUser userData = DependencyService.Get<IUser>();
+            // User user = userData.GetAsync(entry.UserId).Result;
+            Name = entry.Name;
+            Score = entry.Score;
+            ImageOpenClose = new Lazy<Image>(() => {
+                IUser userData = DependencyService.Get<IUser>();
+                User user = userData.GetAsync(entry.UserId).Result;
+                return new Image() { Source = ImageSource.FromStream(() => new MemoryStream(user.Picture)) };
+            });
+            //ImageOpenClose = new Lazy<Image>();
+            //ImageOpenClose.Value.Source = ImageSource.FromStream(() => new MemoryStream(user.Picture));
+        }
+
+    }
+}

--- a/Encountify/Models/ScoreboardEntry.cs
+++ b/Encountify/Models/ScoreboardEntry.cs
@@ -7,6 +7,7 @@ namespace Encountify.Models
     public class ScoreboardEntry : IComparable<ScoreboardEntry>
     {
         public string Name { get; set; } = "";
+        public int UserId { get; set; }
         public int Score { get; set; } = 0;
         public int CompareTo(ScoreboardEntry other)
         {

--- a/Encountify/Models/VisitedLocations.cs
+++ b/Encountify/Models/VisitedLocations.cs
@@ -11,5 +11,6 @@ namespace Encountify.Models
         public int Id { get; set; }
         public int UserId { get; set; }
         public int LocationId { get; set; }
+        public int Points { get; set; }
     }
 }

--- a/Encountify/Services/DatabaseAccess.cs
+++ b/Encountify/Services/DatabaseAccess.cs
@@ -124,8 +124,10 @@ namespace Encountify.Services
                 return (element as Location).Name;
             /*else if (typeof(T) == typeof(User))
                 return (element as User).Username;*/
+            else if (typeof(T) == typeof(VisitedLocations))
+                return (element as VisitedLocations).UserId.ToString() + "/" + (element as VisitedLocations).LocationId.ToString();
             else
-                throw new Exception("Database of given type is not supported");
+                throw new Exception("Database of given type does not support name");
         }
 
     }

--- a/Encountify/Services/ScoreboardCreation.cs
+++ b/Encountify/Services/ScoreboardCreation.cs
@@ -14,7 +14,7 @@ namespace Encountify.Services
         {
             IUser userData = DependencyService.Get<IUser>();    //new DatabaseAccess<User>();
             List<User> users = (List<User>)userData.GetAllAsync().Result;
-            DatabaseAccess<VisitedLocations> visitedLocationsData = new DatabaseAccess<VisitedLocations>(); 
+            DatabaseAccess<VisitedLocations> visitedLocationsData = new DatabaseAccess<VisitedLocations>();
             List<VisitedLocations> visitedLocations = (List<VisitedLocations>)visitedLocationsData.GetAllAsync().Result;
 
             var query =
@@ -25,7 +25,9 @@ namespace Encountify.Services
                     new
                     {
                         Users = user.Username,
-                        Locations = locations.Select(loc => loc.LocationId)
+                        UserId = user.Id,
+                        Locations = locations.Select(loc => loc.LocationId),
+                        Points = locations.Select(loc => loc.Points)
                     });
             List<ScoreboardEntry> results = new List<ScoreboardEntry>();
 
@@ -34,7 +36,8 @@ namespace Encountify.Services
                 results.Add(new ScoreboardEntry()
                 {
                     Name = group.Users,
-                    Score = group.Locations.Count()
+                    Score = group.Points.Sum(),
+                    UserId = group.UserId
                 });
             }
 

--- a/Encountify/Services/ScoreboardCreation.cs
+++ b/Encountify/Services/ScoreboardCreation.cs
@@ -10,7 +10,7 @@ namespace Encountify.Services
     public class ScoreboardCreation
     {
         public ScoreboardEntry this[int i] => CreateScoreboard().ToArray()[i];
-        public List<ScoreboardEntry> CreateScoreboard(bool reversed = false)
+        public List<ScoreboardEntry> CreateScoreboard(bool reversed = true)
         {
             IUser userData = DependencyService.Get<IUser>();    //new DatabaseAccess<User>();
             List<User> users = (List<User>)userData.GetAllAsync().Result;

--- a/Encountify/Services/UserAccess.cs
+++ b/Encountify/Services/UserAccess.cs
@@ -24,7 +24,7 @@ namespace Encountify.Services
 
             foreach (User oldElement in oldElements)
             {
-                if (String.Equals(user.Username, user.Username))
+                if (String.Equals(user.Username, oldElement.Username))
                     return Task.FromResult(false);
             }
 

--- a/Encountify/ViewModels/ScoreboardPageViewModel.cs
+++ b/Encountify/ViewModels/ScoreboardPageViewModel.cs
@@ -11,16 +11,16 @@ namespace Encountify.ViewModels
 {
     public class ScoreboardPageViewModel : BaseViewModel
     {
-        public ObservableCollection<ScoreboardEntry> Scoreboard { get; }
+        public ObservableCollection<ScoreboardCell> Scoreboard { get; }
 
         public ScoreboardPageViewModel()
         {
-            Scoreboard = new ObservableCollection<ScoreboardEntry>();
+            Scoreboard = new ObservableCollection<ScoreboardCell>();
             var scoreboardCreator = new ScoreboardCreation();
             var list = scoreboardCreator.CreateScoreboard();
 
             foreach (var element in list)
-                Scoreboard.Add(element);
+                Scoreboard.Add(new ScoreboardCell(element));
         }
     }
 }

--- a/Encountify/Views/MapPage.xaml.cs
+++ b/Encountify/Views/MapPage.xaml.cs
@@ -48,6 +48,17 @@ namespace Encountify.Views
 
                 if (distance <= 0.03)
                 {
+                    var access = new DatabaseAccess<Location>();
+                    var locationList = await access.GetAllAsync();
+
+                    Location visited = locationList.FirstOrDefault(s => s.Name == e.Pin.Label);
+                    if(visited != null)
+                    {
+                        // hardcoded 100, it might be nice to change to something later on
+                        VisitedLocations newVisit = new VisitedLocations() { LocationId = visited.Id, UserId = App.UserID, Points = 100};
+                        var visitedAccess = new DatabaseAccess<VisitedLocations>();
+                        await visitedAccess.AddAsync(newVisit);
+                    }
                     await DisplayAlert($"You visited {e.Pin.Label}!" , distance.ToString(), "OK");
                 }
             };

--- a/Encountify/Views/ScoreboardPage.xaml
+++ b/Encountify/Views/ScoreboardPage.xaml
@@ -21,6 +21,7 @@
                         ColumnDefinitions="Auto,*"
                         RowDefinitions="Auto, *">
 
+                        <Image x:Name="DownloadedImageSource" Aspect="AspectFit" HeightRequest="60" WidthRequest="70" Source="{Binding ImageOpenClose.Value.Source}"/>
                         <Label
                             Grid.Column="1"
                             FontAttributes="Bold"


### PR DESCRIPTION
-Updated VisitedLocation to contain points and made possible calculation of score
-Changed scoreboard to display image
-Completed requirement for lazy initialization by initializing image source lazily.
-Fixed a bug that made registration of new users impossible

Some explanation of laziness: Xamarin.Forms CollectionView does not load all element at the same time, so it only access observable collection when it is neccessary, for example, when user scroll some more. (You can test this by creating a lot of users and tracking GetAsync in UserAccess).

Things left todo:
-Update style of scoreboard, cause now it just packs all together and calls it a day
-Figure out a logic for giving points (it might be a decent opportunity to use delegates)